### PR TITLE
changed user.username to user.attributes.name on the chat page

### DIFF
--- a/src/component/chatList.tsx
+++ b/src/component/chatList.tsx
@@ -34,7 +34,6 @@ export function ChatList({
       </div>
     );
   }
-
   return (
     <div className="divide-y divide-gray-200">
       {matches.map((match) => {
@@ -43,7 +42,6 @@ export function ChatList({
           match.user1_id === userId
             ? (match.user2 as User)
             : (match.user1 as User);
-
         return (
           <div
             key={match.id}
@@ -62,7 +60,7 @@ export function ChatList({
               />
             </div>
             <div>
-                <h3 className="font-medium">{otherUser.username || "Runner"}</h3>
+                <h3 className="font-medium">{otherUser.attributes.name || "Runner"}</h3>
                 <p className="text-sm text-zinc-800">
                   Matched {new Date(match.created_at).toLocaleDateString()}
                 </p>

--- a/src/hooks/useMatches.ts
+++ b/src/hooks/useMatches.ts
@@ -19,8 +19,8 @@ export function useMatches(userId: string | undefined) {
         .select(
           `
           *,
-          user1:user1_id(id, username, avatar_url),
-          user2:user2_id(id, username, avatar_url)
+          user1:user1_id(id, attributes, username, avatar_url),
+          user2:user2_id(id, attributes, username, avatar_url)
         `
         )
         .or(`user1_id.eq.${userId},user2_id.eq.${userId}`);


### PR DESCRIPTION
Fixes bug, on chat page

Some fields missing when doing type cast to User

```js
const otherUser =
          match.user1_id === userId
            ? (match.user2 as User)
            : (match.user1 as User);
```

Will have to change `useMatches` if we want to add the rest of the User fields